### PR TITLE
Change from api.branch.io to api2.branch.io

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -32,7 +32,7 @@ class Client
     protected $http;
 
 
-    const API_URL = 'https://api.branch.io/v1/';
+    const API_URL = 'https://api2.branch.io/v1/';
 
     /**
      * Client constructor.


### PR DESCRIPTION
The recommended API subdomain now seems to be `api2`: https://github.com/BranchMetrics/branch-deep-linking-public-api/commit/9c1a2e01e5bb2b53595995874641b9053904eb97